### PR TITLE
Simplify the GitHub Actions config and bring it more in line with standard configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-  pull_request_target:
+  pull_request:
   schedule:
     - cron: "6 20 * * 6"
 
@@ -48,6 +48,7 @@ jobs:
           - "3.1"
           - ruby-head
           - jruby-9.2
+          - jruby-9.3
     steps:
       - uses: actions/checkout@v1
       - name: Set up Ruby


### PR DESCRIPTION
This commit:

1. Replaces pull_request_target with pull_request
2. Uses the built-in bundle install and cache in the ruby/setup-ruby action
3. Adds JRuby 9.3